### PR TITLE
Includes forks when searching repositories

### DIFF
--- a/client/src/services/github.js
+++ b/client/src/services/github.js
@@ -30,7 +30,10 @@ export async function loadAllStars (accessToken) {
 }
 
 export async function loadSuggestions ({ value, accessToken }) {
-  const response = await fetch(`https://api.github.com/search/repositories?q=${value}`, makeReqOpts(accessToken))
+  const response = await fetch(
+    'https://api.github.com/search/repositories?q=' + encodeURIComponent(`${value} fork:true`),
+    makeReqOpts(accessToken)
+  )
   if (response.status !== 200) { throw new Error() }
   return response.json()
 }


### PR DESCRIPTION
Hey Vlad 👋

What about showing forks in search results ? Sometimes even important projects are "forks" on GH so maybe it would be relevant to include them by default.

Bye 🙇

---

> From : <https://docs.github.com/en/github/searching-for-information-on-github/searching-in-forks> & <https://docs.github.com/en/rest/reference/search#constructing-a-search-query>.